### PR TITLE
Review items classified as borken

### DIFF
--- a/_data/economy.yaml
+++ b/_data/economy.yaml
@@ -19,7 +19,7 @@
     - http://youtu.be/HKcVI1rNz44?t=10m57s
 - title: Pirate insurance for questionably obtained ships
   category: Economy
-  status: Broken
+  status: Not implemented
   tags:
     - steal
     - pirate
@@ -37,7 +37,7 @@
     expenses which will also include paying landing fees, trade tariffs
 - title: Fake hull IDs
   category: Economy
-  status: Broken
+  status: Not implemented
   tags:
     - steal
     - pirate

--- a/_data/engine.yaml
+++ b/_data/engine.yaml
@@ -80,10 +80,11 @@
     - http://youtu.be/2jcCwDs2rbw?t=5m26s
 - title: Linux Support
   category: Engine
-  status: Broken
+  status: Not implemented
   sources:
     - https://www.youtube.com/watch?v=FYp38vTFpW8&t=21m48s
     - https://www.kickstarter.com/projects/cig/star-citizen/posts/342048
+    - https://youtu.be/zm6KhET7Lmk?t=408
 - title: Take advantage of multi-core processors
   category: Engine
   status: Completed
@@ -113,7 +114,7 @@
     point."
 - title: Angle penetration damage
   category: Engine
-  status: Broken
+  status: Not implemented
   sources:
     - https://youtu.be/qwbU9FG5XlQ
   quote: So there will definitely be the angle of incidence of a projectile hitting

--- a/_data/levels.yaml
+++ b/_data/levels.yaml
@@ -7,13 +7,6 @@
     - https://youtu.be/FsWDLHVYNHI?t=534
     - https://youtu.be/g4UaUmJ8Ho8?t=294
   quote: CIG Developer|We are planning on attempting a single shard
-- title: Procedural generation missions
-  category: Levels
-  status: Not implemented
-  sources:
-    - https://youtu.be/VK4wHImGNAQ?t=424
-  quote: "So we're gonna combine some scripted missions with procedural generation
-    missions."
 - title: Runtime generation of planets
   category: Levels
   status: In alpha
@@ -57,11 +50,6 @@
   quote: "In 3.0 as we're demonstrating; every planet, every moon, um will be fully
     done rendered physicalized, you can land on any part of em, walk all the way around
     it if you want, if you've got uh months to do that cause they're quite large."
-- title: Seamless planetary/lunar landing
-  category: Levels
-  status: Completed
-  sources:
-    - https://youtu.be/Z-3YBuFI3iI?t=43m45s
 - title: Planetside module
   category: Levels
   status: Compromised
@@ -244,12 +232,6 @@
   status: Stagnant
   sources:
     - https://youtu.be/-y0GQV_Bx4U?t=242
-- title: Planet day/night cycle
-  category: Levels
-  status: Completed
-  sources:
-    - http://youtu.be/w5M5DXzcMmg?t=3m42s
-    - https://www.youtube.com/watch?v=HEa7u7hf3Ro
 - title: Arena Commander starts as 20 cubic kilometers
   category: Levels
   status: Completed

--- a/_data/levels.yaml
+++ b/_data/levels.yaml
@@ -109,7 +109,7 @@
     into their instance every time."
 - title: Astro Arena
   category: Levels
-  status: Broken
+  status: Not implemented
   tags:
     - zero-g
     - sataball

--- a/_data/mechanics.yaml
+++ b/_data/mechanics.yaml
@@ -1106,7 +1106,7 @@
   - http://youtu.be/2jcCwDs2rbw?t=7m44s
 - title: In depth non-FTL communication
   category: Mechanics
-  status: Broken
+  status: Not implemented
   sources:
   - http://youtu.be/Q4OB9Yfo-0Q?t=2m55s
   - http://youtu.be/PCG4dZ1mYRw?t=7m50s
@@ -1566,7 +1566,7 @@
   - https://forums.robertsspaceindustries.com/discussion/49257/pledger-engine-modifier-upgrade-package
 - title: Hull breaches
   category: Mechanics
-  status: Broken
+  status: Not implemented
   sources:
   - https://youtu.be/Wk9V1SUHi7w?t=61
   - https://youtu.be/H4Z2Fr9fHMc?t=217

--- a/_data/mechanics.yaml
+++ b/_data/mechanics.yaml
@@ -893,11 +893,6 @@
   status: Not implemented
   sources:
   - http://youtu.be/_9zJm8pK48E?t=1m14s
-- title: "Location for contributors' names to be found in the PU"
-  category: Mechanics
-  status: Not implemented
-  sources:
-  - http://youtu.be/_9zJm8pK48E?t=8m13s
 - title: Organization reputation system
   category: Mechanics
   status: Not implemented
@@ -1496,7 +1491,7 @@
   status: Completed
   sources:
   - https://robertsspaceindustries.com/module/arena-commander
-- title: G-Force effects and safety systems
+- title: G-Force effects
   category: Mechanics
   status: Completed
   sources:

--- a/_data/mechanics.yaml
+++ b/_data/mechanics.yaml
@@ -1082,7 +1082,7 @@
   quote: "We built a whole like we got a what we call a 'highlight camera' system"
 - title: Detailed procedural ship destruction for large ships
   category: Mechanics
-  status: Completed
+  status: In alpha
   sources:
   - http://youtu.be/vRR1eIGnT04?t=17m53s
 - title: Taxes within Organizations

--- a/_data/npcs.yaml
+++ b/_data/npcs.yaml
@@ -22,7 +22,7 @@
     - https://youtu.be/Z-3YBuFI3iI?t=1800
 - title: Immersive landing pad and traffic control from NPCs
   category: NPCs
-  status: Completed
+  status: In alpha
   sources:
     - https://youtu.be/Z-3YBuFI3iI?t=49m27s
 - title: NPC managers replace destroyed items and fix up player caused damage

--- a/_data/promo.yaml
+++ b/_data/promo.yaml
@@ -126,7 +126,7 @@
     - https://robertsspaceindustries.com/comm-link/transmission/14184-Letter-From-The-Chairman
   quote: We want to make the Best Damn Space Sim Ever, and with your continued support
     I know we will.
-- title: Move Wingman out of the basement. (Move Austin team to larger office)
+- title: Move Wingman out of the basement. (Move Austinb team to larger office)
   category: Promo
   status: Completed
   tags:
@@ -157,11 +157,6 @@
   sources:
     - https://www.facebook.com/215475438505750/photos/a.429027047150587.107566.215475438505750/998323386887614/
     - http://www.imdb.com/title/tt5561564/
-- title: Procedural Generation R&D Team
-  category: Promo
-  status: Completed
-  tags:
-    - Official Stretch Goal
 - title: Shroud of the Avatar Crossbow
   category: Promo
   status: Stagnant

--- a/_data/shop.yaml
+++ b/_data/shop.yaml
@@ -36,9 +36,10 @@
     - http://youtu.be/PCG4dZ1mYRw?t=13m53s
 - title: Full color map of the game universe
   category: Shop
-  status: Completed
+  status: Not implemented
   sources:
     - http://web.archive.org/web/20130429140101/http://robertsspaceindustries.com/add-ons/
+    - https://robertsspaceindustries.com/pledge/Add-Ons/Game-Universe-Map
   quote: RSI Site|this handy full-color map of the Star Citizen world, which will
     display all “known” systems and their jump points as well as information about
     their resources, alliances and more!


### PR DESCRIPTION
* 'Pirate insurance for questionably obtained ships', 'Fake hull IDs'
  The evidence attatched to this does in no way indicate that pirate insurance or something equivalent will not happen. More to the opposite it emphasizes that priacy is a important occupation in the game.

* 'Linux Support'
  The evidence does not hint to linux support to be dropped, added link that states it's on the long term road map

* 'Angle penetration damage'
  The evidence does no no way suggest that this is not going to be implemented.

* 'Astro Arena'
  The evidence has CR state "Sataball will be in a later patch  [but] not in this one"

* 'In depth non-FTL communication'
  The evidence does no no way suggest this was dropped from consideration.

* 'Hull breaches'
  The 'evidence' for this to be broken is a forum post talking about an article they supposedly read claiming that hull breaches won't be implemented. The post is from 2013, evidence of CR talking about hull breaches being a thing is at least present in 2014 making claim of a broken promise outdated.
